### PR TITLE
Add continuous integration action

### DIFF
--- a/hi-backend/.github/workflows/ci.yml
+++ b/hi-backend/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Continuous Integration
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 3.1.2
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.2
+    - name: Build and test with Minitest
+      run: |
+        gem install bundler
+        bundle install
+        bundle exec rake test


### PR DESCRIPTION
This pull request adds a continuous integration action for a Rails application using GitHub Actions with a Minitest test suite. The action is triggered by a push to the repository and runs the build job defined in the ci.yml file. The build job sets up the Ruby environment, installs dependencies, and runs the Minitest tests for the Rails application. If any tests fail, the GitHub action fails and a notification is sent. The Ruby version used in the action is 3.1.2.